### PR TITLE
Add Ring Extender G2 additional product ID ref

### DIFF
--- a/packages/config/config/devices/0x0346/range_extender_gen2.json
+++ b/packages/config/config/devices/0x0346/range_extender_gen2.json
@@ -3,23 +3,21 @@
 	"manufacturerId": "0x0346",
 	"label": "4AR1SZ-0EN0",
 	"description": "Range Extender (2nd generation)",
-	"devices": [
-		{
+	"devices": [{
 			"productType": "0x0401",
 			"productId": "0x0301",
 			"zwaveAllianceId": 4148
 		},
 		{
 			"productType": "0x0401",
-			"productId": "0x0401",
+			"productId": "0x0401"
 		}
 	],
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"paramInformation": [
-		{
+	"paramInformation": [{
 			"#": "1",
 			"label": "Heartbeat Interval",
 			"valueSize": 1,
@@ -55,8 +53,7 @@
 			"defaultValue": 1,
 			"unsigned": true,
 			"allowManualEntry": false,
-			"options": [
-				{
+			"options": [{
 					"label": "Always off",
 					"value": 0
 				},


### PR DESCRIPTION
Add Ring Extender G2 additional product ID ref "productType": "0x0401", 	"productId": "0x0401"

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
